### PR TITLE
Removed private RISC-V config from s4e-mac

### DIFF
--- a/s4e-mac.core_desc
+++ b/s4e-mac.core_desc
@@ -8,25 +8,25 @@ InstructionSet X_S4E_MAC extends RV32I {
   instructions {
     RESET_ACC { // v-- funct7       v-- funct3
       encoding: 7'd0 :: 10'b0 :: 3'd0 :: 5'b0 :: 7'b0001011;
-      assembly:"";
+      assembly: {"s4e.reset_acc", ""};
       behavior: ACC = 0;
     }
 
     GET_ACC_LO {
       encoding: 7'd1 :: 10'b0 :: 3'd0 :: rd[4:0] :: 7'b0001011;
-      assembly:"{name(rd)}";
+      assembly: {"s4e.get_acc_lo", "{name(rd)}"};
       behavior: if (rd != 0) X[rd] = ACC[31:0];
     }
 
     GET_ACC_HI {
       encoding: 7'd2 :: 10'b0 :: 3'd0 :: rd[4:0] :: 7'b0001011;
-      assembly:"{name(rd)}";
+      assembly: {"s4e.get_acc_hi", "{name(rd)}"};
       behavior: if (rd != 0) X[rd] = ACC[63:32];
     }
 
     MACU_32 {
       encoding: 7'd0 :: rs2[4:0] :: rs1[4:0] :: 3'd1 :: 5'b0 :: 7'b0001011;
-      assembly:"{name(rs1)}, {name(rs2)}";
+      assembly: {"s4e.macu_32", "{name(rs1)}, {name(rs2)}"};
       behavior: {
         unsigned<64> mul = X[rs1]    * X[rs2];
         unsigned<33> add = mul[31:0] + ACC[31:0];
@@ -36,7 +36,7 @@ InstructionSet X_S4E_MAC extends RV32I {
 
     MACS_32 {
       encoding: 7'd1 :: rs2[4:0] :: rs1[4:0] :: 3'd1 :: 5'b0 :: 7'b0001011;
-      assembly:"{name(rs1)}, {name(rs2)}";
+      assembly: {"s4e.macs_32", "{name(rs1)}, {name(rs2)}"};
       behavior: {
         signed<64> mul = ((signed) X[rs1])    * ((signed) X[rs2]);
         signed<33> add = ((signed) mul[31:0]) + ((signed) ACC[31:0]);
@@ -46,7 +46,7 @@ InstructionSet X_S4E_MAC extends RV32I {
 
     MACU_64 {
       encoding: 7'd0 :: rs2[4:0] :: rs1[4:0] :: 3'd2 :: 5'b0 :: 7'b0001011;
-      assembly:"{name(rs1)}, {name(rs2)}";
+      assembly: {"s4e.macu_64", "{name(rs1)}, {name(rs2)}"};
       behavior: {
         unsigned<64> mul = X[rs1] * X[rs2];
         unsigned<65> add = mul    + ACC;
@@ -56,7 +56,7 @@ InstructionSet X_S4E_MAC extends RV32I {
 
     MACS_64 {
       encoding: 7'd1 :: rs2[4:0] :: rs1[4:0] :: 3'd2 :: 5'b0 :: 7'b0001011;
-      assembly:"{name(rs1)}, {name(rs2)}";
+      assembly: {"s4e.macs_64", "{name(rs1)}, {name(rs2)}"};
       behavior: {
         signed<64> mul = ((signed) X[rs1]) * ((signed) X[rs2]);
         signed<65> add =           mul     + ((signed) ACC);

--- a/s4e-mac.core_desc
+++ b/s4e-mac.core_desc
@@ -1,4 +1,4 @@
-import "CoreDSL-Instruction-Set-Description/RV32I.core_desc"
+import "../rv_base/RV32I.core_desc"
 
 InstructionSet X_S4E_MAC extends RV32I {
   architectural_state {

--- a/s4e-mac.core_desc
+++ b/s4e-mac.core_desc
@@ -1,6 +1,6 @@
-import "CoreDSL-Instruction-Set-Description/RISCVBase.core_desc"
+import "CoreDSL-Instruction-Set-Description/RV32I.core_desc"
 
-InstructionSet X_S4E_MAC extends RISCVBase {
+InstructionSet X_S4E_MAC extends RV32I {
   architectural_state {
     register unsigned<64> ACC;
   }

--- a/s4e-mac.core_desc
+++ b/s4e-mac.core_desc
@@ -11,19 +11,19 @@ InstructionSet X_S4E_MAC extends RV32I {
       assembly:"";
       behavior: ACC = 0;
     }
-    
+
     GET_ACC_LO {
       encoding: 7'd1 :: 10'b0 :: 3'd0 :: rd[4:0] :: 7'b0001011;
       assembly:"{name(rd)}";
       behavior: if (rd != 0) X[rd] = ACC[31:0];
     }
-    
+
     GET_ACC_HI {
       encoding: 7'd2 :: 10'b0 :: 3'd0 :: rd[4:0] :: 7'b0001011;
       assembly:"{name(rd)}";
       behavior: if (rd != 0) X[rd] = ACC[63:32];
     }
-    
+
     MACU_32 {
       encoding: 7'd0 :: rs2[4:0] :: rs1[4:0] :: 3'd1 :: 5'b0 :: 7'b0001011;
       assembly:"{name(rs1)}, {name(rs2)}";
@@ -33,7 +33,7 @@ InstructionSet X_S4E_MAC extends RV32I {
         ACC = add[31:0];
       }
     }
-    
+
     MACS_32 {
       encoding: 7'd1 :: rs2[4:0] :: rs1[4:0] :: 3'd1 :: 5'b0 :: 7'b0001011;
       assembly:"{name(rs1)}, {name(rs2)}";
@@ -43,7 +43,7 @@ InstructionSet X_S4E_MAC extends RV32I {
         ACC = add[31:0]; // bit range always yields unsigned type
       }
     }
-    
+
     MACU_64 {
       encoding: 7'd0 :: rs2[4:0] :: rs1[4:0] :: 3'd2 :: 5'b0 :: 7'b0001011;
       assembly:"{name(rs1)}, {name(rs2)}";
@@ -53,7 +53,7 @@ InstructionSet X_S4E_MAC extends RV32I {
         ACC = add[63:0];
       }
     }
-    
+
     MACS_64 {
       encoding: 7'd1 :: rs2[4:0] :: rs1[4:0] :: 3'd2 :: 5'b0 :: 7'b0001011;
       assembly:"{name(rs1)}, {name(rs2)}";

--- a/s4e-mac.test-invalid.s
+++ b/s4e-mac.test-invalid.s
@@ -1,0 +1,28 @@
+# MC test of sample S4E MAC instruction extensions
+
+# RUN: not llvm-mc -triple=riscv32 --mattr=+xs4emac %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+s4e.reset_acc 0
+# CHECK-ERROR: invalid operand for instruction
+
+s4e.reset_acc t1
+# CHECK-ERROR: invalid operand for instruction
+
+s4e.get_acc_lo 0
+# CHECK-ERROR: invalid operand for instruction
+
+s4e.get_acc_hi 0
+# CHECK-ERROR: invalid operand for instruction
+
+s4e.macu_32 s5, 0
+# CHECK-ERROR: invalid operand for instruction
+
+s4e.macs_32 0, a7
+# CHECK-ERROR: invalid operand for instruction
+
+s4e.macu_64 s5, 0
+# CHECK-ERROR: invalid operand for instruction
+
+s4e.macs_64 0, a7
+# CHECK-ERROR: invalid operand for instruction

--- a/s4e-mac.test.c
+++ b/s4e-mac.test.c
@@ -9,25 +9,25 @@ int main() {
   asm("add x3, x4, x5");
 
   // CHECK: 0b 00 00 00 reset_acc
-  asm("reset_acc");
+  asm("s4e.reset_acc");
 
   // CHECK: 0b 03 00 02 get_acc_lo x6
-  asm("get_acc_lo x6");
+  asm("s4e.get_acc_lo x6");
 
   // CHECK: 8b 0c 00 04 get_acc_hi x25
-  asm("get_acc_hi x25");
+  asm("s4e.get_acc_hi x25");
 
   // CHECK: 0b 90 1a 01 macu_32 x21, x17
-  asm("macu_32 x21, x17");
+  asm("s4e.macu_32 x21, x17");
 
   // CHECK: 0b 90 1a 03 macs_32 x21, x17
-  asm("macs_32 x21, x17");
+  asm("s4e.macs_32 x21, x17");
 
   // CHECK: 0b a0 1a 01 macu_64 x21, x17
-  asm("macu_64 x21, x17");
+  asm("s4e.macu_64 x21, x17");
 
   // CHECK: 0b a0 1a 03 macs_64 x21, x17
-  asm("macs_64 x21, x17");
+  asm("s4e.macs_64 x21, x17");
 
   return 42;
 }

--- a/s4e-mac.test.c
+++ b/s4e-mac.test.c
@@ -1,6 +1,6 @@
 // Basic test of assembly and layout of sample S4E MAC instruction extensions
 
-// RUN: %clang --target=riscv32 -march=rv32ixs4emac -c -o %t.o %s
+// RUN: clang --target=riscv32 -march=rv32ixs4emac -c -o %t.o %s
 // RUN: llvm-objdump --disassembler-options=numeric -d %t.o | FileCheck %s
 
 int main() {

--- a/s4e-mac.test.c
+++ b/s4e-mac.test.c
@@ -8,25 +8,25 @@ int main() {
   // CHECK: b3 01 52 00 add x3, x4, x5
   asm("add x3, x4, x5");
 
-  // CHECK: 0b 00 00 00 reset_acc
+  // CHECK: 0b 00 00 00 s4e.reset_acc
   asm("s4e.reset_acc");
 
-  // CHECK: 0b 03 00 02 get_acc_lo x6
+  // CHECK: 0b 03 00 02 s4e.get_acc_lo x6
   asm("s4e.get_acc_lo x6");
 
-  // CHECK: 8b 0c 00 04 get_acc_hi x25
+  // CHECK: 8b 0c 00 04 s4e.get_acc_hi x25
   asm("s4e.get_acc_hi x25");
 
-  // CHECK: 0b 90 1a 01 macu_32 x21, x17
+  // CHECK: 0b 90 1a 01 s4e.macu_32 x21, x17
   asm("s4e.macu_32 x21, x17");
 
-  // CHECK: 0b 90 1a 03 macs_32 x21, x17
+  // CHECK: 0b 90 1a 03 s4e.macs_32 x21, x17
   asm("s4e.macs_32 x21, x17");
 
-  // CHECK: 0b a0 1a 01 macu_64 x21, x17
+  // CHECK: 0b a0 1a 01 s4e.macu_64 x21, x17
   asm("s4e.macu_64 x21, x17");
 
-  // CHECK: 0b a0 1a 03 macs_64 x21, x17
+  // CHECK: 0b a0 1a 03 s4e.macs_64 x21, x17
   asm("s4e.macs_64 x21, x17");
 
   return 42;

--- a/s4e-mac.test.s
+++ b/s4e-mac.test.s
@@ -1,0 +1,41 @@
+# MC test of sample S4E MAC instruction extensions
+
+# RUN: llvm-mc -triple=riscv32 --mattr=+xs4emac -show-encoding %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INSTR
+# RUN: not llvm-mc -triple riscv32 %s 2>&1 \
+# RUN:     | FileCheck -check-prefix=CHECK-NO-EXT %s
+
+s4e.reset_acc
+# CHECK-INSTR: s4e.reset_acc
+# CHECK-ENCODING: [0x0b,0x00,0x00,0x00]
+# CHECK-NO-EXT: instruction requires the following: 'XS4EMAC' (X_S4E_MAC Extension){{$}}
+
+s4e.get_acc_lo t1
+# CHECK-INSTR: s4e.get_acc_lo t1
+# CHECK-ENCODING: [0x0b,0x03,0x00,0x02]
+# CHECK-NO-EXT: instruction requires the following: 'XS4EMAC' (X_S4E_MAC Extension){{$}}
+
+s4e.get_acc_hi s9
+# CHECK-INSTR: s4e.get_acc_hi s9
+# CHECK-ENCODING: [0x8b,0x0c,0x00,0x04]
+# CHECK-NO-EXT: instruction requires the following: 'XS4EMAC' (X_S4E_MAC Extension){{$}}
+
+s4e.macu_32 s5, a7
+# CHECK-INSTR: s4e.macu_32 s5, a7
+# CHECK-ENCODING: [0x0b,0x90,0x1a,0x01]
+# CHECK-NO-EXT: instruction requires the following: 'XS4EMAC' (X_S4E_MAC Extension){{$}}
+
+s4e.macs_32 s5, a7
+# CHECK-INSTR: s4e.macs_32 s5, a7
+# CHECK-ENCODING: [0x0b,0x90,0x1a,0x03]
+# CHECK-NO-EXT: instruction requires the following: 'XS4EMAC' (X_S4E_MAC Extension){{$}}
+
+s4e.macu_64 s5, a7
+# CHECK-INSTR: s4e.macu_64 s5, a7
+# CHECK-ENCODING: [0x0b,0xa0,0x1a,0x01]
+# CHECK-NO-EXT: instruction requires the following: 'XS4EMAC' (X_S4E_MAC Extension){{$}}
+
+s4e.macs_64 s5, a7
+# CHECK-INSTR: s4e.macs_64 s5, a7
+# CHECK-ENCODING: [0x0b,0xa0,0x1a,0x03]
+# CHECK-NO-EXT: instruction requires the following: 'XS4EMAC' (X_S4E_MAC Extension){{$}}


### PR DESCRIPTION
More trivial cleanup - doesn't appear that it needs a private copy of the generic RISC-V instruction set definitions?