### PR TITLE
SEAL5 CI/CD Flow Trigger

### DIFF
--- a/.github/workflows/s4e_riscv_cdsl.yml
+++ b/.github/workflows/s4e_riscv_cdsl.yml
@@ -27,7 +27,7 @@ jobs:
       uses: peter-evans/repository-dispatch@v3
       with:
         token: ${{ secrets.REPO_ACCESS_TOKEN }}
-        repository: ${{ 'kebi-be/etiss_wysiwyng' }}
+        repository: ${{ 'kebi-be/etiss' }}
         event-type: s4e-cdl-event
         client-payload: '{"triggered_by": "${{ github.repository }}", "run_id": "${{ github.run_id }}"}'
         

--- a/.github/workflows/s4e_riscv_cdsl.yml
+++ b/.github/workflows/s4e_riscv_cdsl.yml
@@ -32,3 +32,6 @@ jobs:
         repositry: ${{ matrix.repo }}
         event-type: s4e-cdl-event
         client-payload: '{ "trigger_repo_run_id": "${{ github.run_id }}" }'
+
+
+        

--- a/.github/workflows/s4e_riscv_cdsl.yml
+++ b/.github/workflows/s4e_riscv_cdsl.yml
@@ -25,14 +25,14 @@ jobs:
       with:
         name: riscv-core-dsl-files
         path: /home/runner/work/riscv-coredsl-extensions/riscv-coredsl-extensions/*.core_desc      
-        
-    #- name: Trigger Seal5 Workflow
-     # uses: peter-evans/repository-dispatch@v3
-      #with:
-       # token: ${{ secrets.REPO_ACCESS_TOKEN }}
-        #repository: ${{ 'kebi-be/seal5'}}
-       # event-type: s4e-cdl-event
-       # client-payload: '{"triggered_by": "${{ github.repository }}", "run_id": "${{ github.run_id }}"}'
+           
+    - name: Trigger Seal5 Workflow
+      uses: peter-evans/repository-dispatch@v3
+      with:
+       token: ${{ secrets.REPO_ACCESS_TOKEN }}
+       repository: ${{ 'kebi-be/seal5'}}
+       event-type: s4e-cdl-event
+       client-payload: '{"triggered_by": "${{ github.repository }}", "run_id": "${{ github.run_id }}"}'
     
     - name: Trigger ETISS Workflow
       uses: peter-evans/repository-dispatch@v3

--- a/.github/workflows/s4e_riscv_cdsl.yml
+++ b/.github/workflows/s4e_riscv_cdsl.yml
@@ -24,15 +24,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: riscv-core-dsl-files
-        path: /home/runner/work/riscv-coredsl-extensions/riscv-coredsl-extensions/*.core_desc  
-        
-    - name: Trigger ETISS Workflow
-      uses: peter-evans/repository-dispatch@v3
-      with:
-        token: ${{ secrets.REPO_ACCESS_TOKEN }}
-        repository: ${{ 'kebi-be/etiss_wysiwyng' }}
-        event-type: s4e-cdl-event
-        client-payload: '{"triggered_by": "${{ github.repository }}", "run_id": "${{ github.run_id }}"}'        
+        path: /home/runner/work/riscv-coredsl-extensions/riscv-coredsl-extensions/*.core_desc      
         
     - name: Trigger Seal5 Workflow
       uses: peter-evans/repository-dispatch@v3

--- a/.github/workflows/s4e_riscv_cdsl.yml
+++ b/.github/workflows/s4e_riscv_cdsl.yml
@@ -13,19 +13,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      name: Check Modified Files      
-    - run: |
-          ls -al
-          pwd
-          git fetch origin main:main
-          var=$(git diff --name-only --diff-filter=d main~ main) 
-          echo "List of changed files: "$var
-    - name: Upload Artifacts
-      uses: actions/upload-artifact@v4
-      with:
-        name: riscv-core-dsl-files
-        path: /home/runner/work/riscv-coredsl-extensions/riscv-coredsl-extensions/*.core_desc      
-           
+      name: Check Modified Files   
+      
     - name: Trigger Seal5 Workflow
       uses: peter-evans/repository-dispatch@v3
       with:

--- a/.github/workflows/s4e_riscv_cdsl.yml
+++ b/.github/workflows/s4e_riscv_cdsl.yml
@@ -30,7 +30,7 @@ jobs:
       uses: peter-evans/repository-dispatch@v3
       with:
         token: ${{ secrets.REPO_ACCESS_TOKEN }}
-        repository: ${{ 'bkebianyor/seal5'}}
+        repository: ${{ 'kebi-be/seal5'}}
         event-type: s4e-cdl-event
         client-payload: '{"triggered_by": "${{ github.repository }}", "run_id": "${{ github.run_id }}"}'
     
@@ -38,7 +38,7 @@ jobs:
       uses: peter-evans/repository-dispatch@v3
       with:
         token: ${{ secrets.REPO_ACCESS_TOKEN }}
-        repository: ${{ 'bkebianyor/etiss_wysiwyng' }}
+        repository: ${{ 'kebi-be/etiss_wysiwyng' }}
         event-type: s4e-cdl-event
         client-payload: '{"triggered_by": "${{ github.repository }}", "run_id": "${{ github.run_id }}"}'
         

--- a/.github/workflows/s4e_riscv_cdsl.yml
+++ b/.github/workflows/s4e_riscv_cdsl.yml
@@ -26,6 +26,14 @@ jobs:
         name: riscv-core-dsl-files
         path: /home/runner/work/riscv-coredsl-extensions/riscv-coredsl-extensions/*.core_desc  
         
+    - name: Trigger ETISS Workflow
+      uses: peter-evans/repository-dispatch@v3
+      with:
+        token: ${{ secrets.REPO_ACCESS_TOKEN }}
+        repository: ${{ 'kebi-be/etiss_wysiwyng' }}
+        event-type: s4e-cdl-event
+        client-payload: '{"triggered_by": "${{ github.repository }}", "run_id": "${{ github.run_id }}"}'        
+        
     - name: Trigger Seal5 Workflow
       uses: peter-evans/repository-dispatch@v3
       with:

--- a/.github/workflows/s4e_riscv_cdsl.yml
+++ b/.github/workflows/s4e_riscv_cdsl.yml
@@ -26,13 +26,13 @@ jobs:
         name: riscv-core-dsl-files
         path: /home/runner/work/riscv-coredsl-extensions/riscv-coredsl-extensions/*.core_desc      
         
-    - name: Trigger Seal5 Workflow
-      uses: peter-evans/repository-dispatch@v3
-      with:
-        token: ${{ secrets.REPO_ACCESS_TOKEN }}
-        repository: ${{ 'kebi-be/seal5'}}
-        event-type: s4e-cdl-event
-        client-payload: '{"triggered_by": "${{ github.repository }}", "run_id": "${{ github.run_id }}"}'
+    #- name: Trigger Seal5 Workflow
+     # uses: peter-evans/repository-dispatch@v3
+      #with:
+       # token: ${{ secrets.REPO_ACCESS_TOKEN }}
+        #repository: ${{ 'kebi-be/seal5'}}
+       # event-type: s4e-cdl-event
+       # client-payload: '{"triggered_by": "${{ github.repository }}", "run_id": "${{ github.run_id }}"}'
     
     - name: Trigger ETISS Workflow
       uses: peter-evans/repository-dispatch@v3

--- a/.github/workflows/s4e_riscv_cdsl.yml
+++ b/.github/workflows/s4e_riscv_cdsl.yml
@@ -9,29 +9,36 @@ on:
 
 jobs:
   build:
-    strategy:
-      matrix:
-        repo: ['bkebianyor/seal5', 'bkebianyor/etiss_wysiwyng']
     runs-on: ubuntu-latest
 
     steps:
-    - name: Check Modified Files
-      run: |
-        var=$( git diff --name-only HEAD~ HEAD 2>&1) #./get_list_modified_files
-        echo $var
+    - uses: actions/checkout@v4
+      name: Check Modified Files      
+    - run: |
+          ls -al
+          pwd
+          git fetch origin main:main
+          var=$(git diff --name-only --diff-filter=d main~ main) 
+          echo "List of changed files: "$var
     - name: Upload Artifacts
       uses: actions/upload-artifact@v4
       with:
         name: riscv-core-dsl-files
-        path: ${{ github.workspace }}/*.core_desc   
+        path: /home/runner/work/riscv-coredsl-extensions/riscv-coredsl-extensions/*.core_desc  
         
-    - name: Trigger Seal5 and ETISS Workflow
+    - name: Trigger Seal5 Workflow
       uses: peter-evans/repository-dispatch@v3
       with:
         token: ${{ secrets.REPO_ACCESS_TOKEN }}
-        repositry: ${{ matrix.repo }}
+        repository: ${{ 'bkebianyor/seal5'}}
         event-type: s4e-cdl-event
-        client-payload: '{ "trigger_repo_run_id": "${{ github.run_id }}" }'
-
-
+        client-payload: '{"triggered_by": "${{ github.repository }}", "run_id": "${{ github.run_id }}"}'
+    
+    - name: Trigger ETISS Workflow
+      uses: peter-evans/repository-dispatch@v3
+      with:
+        token: ${{ secrets.REPO_ACCESS_TOKEN }}
+        repository: ${{ 'bkebianyor/etiss_wysiwyng' }}
+        event-type: s4e-cdl-event
+        client-payload: '{"triggered_by": "${{ github.repository }}", "run_id": "${{ github.run_id }}"}'
         

--- a/.github/workflows/s4e_riscv_cdsl.yml
+++ b/.github/workflows/s4e_riscv_cdsl.yml
@@ -1,0 +1,34 @@
+name: S4E_CDSL_Workflow
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ "b_github_ci" ]
+  pull_request:
+    branches: [ "b_github_ci" ]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        repo: ['bkebianyor/seal5', 'bkebianyor/etiss_wysiwyng']
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check Modified Files
+      run: |
+        var=$( git diff --name-only HEAD~ HEAD 2>&1) #./get_list_modified_files
+        echo $var
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: riscv-core-dsl-files
+        path: ${{ github.workspace }}/*.core_desc   
+        
+    - name: Trigger Seal5 and ETISS Workflow
+      uses: peter-evans/repository-dispatch@v3
+      with:
+        token: ${{ secrets.REPO_ACCESS_TOKEN }}
+        repositry: ${{ matrix.repo }}
+        event-type: s4e-cdl-event
+        client-payload: '{ "trigger_repo_run_id": "${{ github.run_id }}" }'

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "CoreDSL-Instruction-Set-Description"]
 	path = CoreDSL-Instruction-Set-Description
-	url = https://github.com/Minres/RISCV_ISA_CoreDSL.git
+	url = git@github.com:Minres/RISCV_ISA_CoreDSL.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "CoreDSL-Instruction-Set-Description"]
 	path = CoreDSL-Instruction-Set-Description
-	url = git@github.com:Minres/RISCV_ISA_CoreDSL.git
+	url = https://github.com/Minres/RISCV_ISA_CoreDSL.git


### PR DESCRIPTION
This workflow will trigger SEAL5 and ETISS repositories to start building once there are changes in the riscv-coredsl-description repository. 

- Squash commits to single commit before merge
- kebi-be/etiss und kebi-be/seal5 should be changed to tum-eda/etiss and tum-eda/seal5 respectively
- secret token from tum-eda must be made available for DLR-SE/riscv-coredsl-description to send trigger (repository_dispatch) event to these repositories